### PR TITLE
Local GameplayCues using AvatarActor to emulate properly the behavior of a normal GameplayCue

### DIFF
--- a/README.md
+++ b/README.md
@@ -2355,18 +2355,18 @@ void RemoveGameplayCueLocal(const FGameplayTag GameplayCueTag, const FGameplayCu
 ```c++
 void UPAAbilitySystemComponent::ExecuteGameplayCueLocal(const FGameplayTag GameplayCueTag, const FGameplayCueParameters & GameplayCueParameters)
 {
-	UAbilitySystemGlobals::Get().GetGameplayCueManager()->HandleGameplayCue(GetOwner(), GameplayCueTag, EGameplayCueEvent::Type::Executed, GameplayCueParameters);
+	UAbilitySystemGlobals::Get().GetGameplayCueManager()->HandleGameplayCue(GetAvatarActor()(), GameplayCueTag, EGameplayCueEvent::Type::Executed, GameplayCueParameters);
 }
 
 void UPAAbilitySystemComponent::AddGameplayCueLocal(const FGameplayTag GameplayCueTag, const FGameplayCueParameters & GameplayCueParameters)
 {
-	UAbilitySystemGlobals::Get().GetGameplayCueManager()->HandleGameplayCue(GetOwner(), GameplayCueTag, EGameplayCueEvent::Type::OnActive, GameplayCueParameters);
-	UAbilitySystemGlobals::Get().GetGameplayCueManager()->HandleGameplayCue(GetOwner(), GameplayCueTag, EGameplayCueEvent::Type::WhileActive, GameplayCueParameters);
+	UAbilitySystemGlobals::Get().GetGameplayCueManager()->HandleGameplayCue(GetAvatarActor()(), GameplayCueTag, EGameplayCueEvent::Type::OnActive, GameplayCueParameters);
+	UAbilitySystemGlobals::Get().GetGameplayCueManager()->HandleGameplayCue(GetAvatarActor()(), GameplayCueTag, EGameplayCueEvent::Type::WhileActive, GameplayCueParameters);
 }
 
 void UPAAbilitySystemComponent::RemoveGameplayCueLocal(const FGameplayTag GameplayCueTag, const FGameplayCueParameters & GameplayCueParameters)
 {
-	UAbilitySystemGlobals::Get().GetGameplayCueManager()->HandleGameplayCue(GetOwner(), GameplayCueTag, EGameplayCueEvent::Type::Removed, GameplayCueParameters);
+	UAbilitySystemGlobals::Get().GetGameplayCueManager()->HandleGameplayCue(GetAvatarActor()(), GameplayCueTag, EGameplayCueEvent::Type::Removed, GameplayCueParameters);
 }
 ```
 


### PR DESCRIPTION
The current behavior of the example GameplayCueLocal functions is not working as it would do with a normal GameplayCue.

If we use GetOwner, the gameplay cue will always be executed sending the owner as "MyTarget", inside the GameplayCue.

In case our ASC lives on the PlayerState, and our Character is the Avatar, this will result on inconsistent behavior between executing the GC using this new function, and the normal Execute/Add GameplayCue

GetAvatarActor() instead of GetOwner() fixes this issue.

Check UAbilitySystemComponent::InvokeGameplayCueEvent to confirm that this is the default/expected behavior.